### PR TITLE
feat(sample): add `_meta` sections to homebrew files

### DIFF
--- a/module/data/raceFeature/GiddyRace.json
+++ b/module/data/raceFeature/GiddyRace.json
@@ -1,4 +1,12 @@
 {
+	"_meta": {
+		"version": "1.0.0",
+		"convertedBy": [
+			"Giddy#0001"
+		],
+		"dateAdded": 1649024400,
+		"dateLastModified": 1649024400
+	},
 	"raceFeature": [
 		{
 			"name": "Skeletal",

--- a/module/data/spell/GiddySpell.json
+++ b/module/data/spell/GiddySpell.json
@@ -1,4 +1,12 @@
 {
+	"_meta": {
+		"version": "1.0.0",
+		"convertedBy": [
+			"Giddy#0001"
+		],
+		"dateAdded": 1649024400,
+		"dateLastModified": 1649024400
+	},
 	"spell": [
 		{
 			"name": "Collapse Astronomical Body",

--- a/test/schema/core.json
+++ b/test/schema/core.json
@@ -1,0 +1,47 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "core.json",
+	"version": "0.1.0",
+
+	"type": "object",
+
+	"properties": {
+		"$schema": {"$ref": "shared.json#/definitions/schema"},
+
+		"monster": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"class": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"subclass": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"spell": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"action": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"item": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"itemGroup": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"baseitem": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"variant": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"background": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"charoption": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"condition": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"disease": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"status": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"cult": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"boon": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"psionic": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"psionicDisciplineFocus": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"race": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"subrace": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"vehicle": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+
+		"feat": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"optionalfeature": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"reward": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"vehicleUpgrade": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+
+		"raceFeature": {"$ref": "shared.json#/definitions/raceFeature"},
+		"backgroundFeature": {"$ref": "shared.json#/definitions/backgroundFeature"},
+		"classFeature": {"$ref": "shared.json#/definitions/classFeature"},
+		"subclassFeature": {"$ref": "shared.json#/definitions/subclassFeature"},
+		"psionicDisciplineActive": {"$ref": "shared.json#/definitions/psionicDisciplineActive"},
+		"vehicleWeapon": {"$ref": "shared.json#/definitions/vehicleWeapon"}
+	},
+
+	"additionalProperties": false
+}

--- a/test/schema/homebrew.json
+++ b/test/schema/homebrew.json
@@ -1,0 +1,82 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "homebrew.json",
+	"version": "0.1.0",
+
+	"$comment": "Note: for homebrew files (i.e., those *not* names \"__core.json\"), the file should be named `<brewSourceJson>.json`, where <brewSourceJson> matches the `\"json\": \"MySourceName\"` value for the corresponding source in the homebrew repository.",
+
+	"definitions": {
+		"_meta": {
+			"type": "object",
+			"description": "For homebrew files (i.e., those *not* names \"__core.json\") only.",
+			"properties": {
+				"version": {
+					"type": "string",
+					"description": "The source version, e.g. \"1.2.3\". This should match the source version of the corresponding source in the homebrew repository."
+				},
+				"convertedBy": {
+					"type": "array",
+					"description": "An optional list of people who contributed to creating the data in the file.",
+					"items": {
+						"type": "string",
+						"description": "Contributor name, Discord handle, etc."
+					}
+				},
+				"dateAdded": {
+					"type": "integer",
+					"description": "The epoch timestamp (in seconds) when the file was added to the repository. Not guaranteed to be anywhere near accurate."
+				},
+				"dateLastModified": {
+					"type": "integer",
+					"description": "The epoch timestamp (in seconds) when the file was last modified. Not guaranteed to be anywhere near accurate."
+				}
+			},
+			"required": ["version", "convertedBy", "dateAdded", "dateLastModified"],
+			"additionalProperties": false
+		}
+	},
+
+	"type": "object",
+
+	"properties": {
+		"$schema": {"$ref": "shared.json#/definitions/schema"},
+
+		"_meta": {"$ref": "#/definitions/_meta"},
+
+		"monster": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"class": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"subclass": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"spell": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"action": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"item": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"itemGroup": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"baseitem": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"variant": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"background": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"charoption": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"condition": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"disease": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"status": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"cult": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"boon": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"psionic": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"psionicDisciplineFocus": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"race": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"subrace": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"vehicle": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+
+		"feat": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"optionalfeature": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"reward": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+		"vehicleUpgrade": {"$ref": "shared.json#/definitions/foundrySideDataGenericArray"},
+
+		"raceFeature": {"$ref": "shared.json#/definitions/raceFeature"},
+		"backgroundFeature": {"$ref": "shared.json#/definitions/backgroundFeature"},
+		"classFeature": {"$ref": "shared.json#/definitions/classFeature"},
+		"subclassFeature": {"$ref": "shared.json#/definitions/subclassFeature"},
+		"psionicDisciplineActive": {"$ref": "shared.json#/definitions/psionicDisciplineActive"},
+		"vehicleWeapon": {"$ref": "shared.json#/definitions/vehicleWeapon"}
+	},
+
+	"additionalProperties": false
+}

--- a/test/schema/shared.json
+++ b/test/schema/shared.json
@@ -1,11 +1,14 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "data.json",
-	"version": "0.1.3",
-
-	"type": "object",
+	"$id": "shared.json",
+	"version": "0.1.0",
 
 	"definitions": {
+		"schema": {
+			"description": "An optional key that allows you specify the schema you want to verify against in compatible IDEs.\nIt is  advised that you leave this key out when submitting to the repo.",
+			"type": "string"
+		},
+
 		"foundryEffectObject": {
 			"type": "object",
 			"properties": {
@@ -94,46 +97,12 @@
 			"type": "array",
 			"uniqueItems": true,
 			"items": {"$ref": "#/definitions/foundrySideDataGeneric"}
-		}
-	},
-
-	"properties": {
-		"$schema": {
-			"description": "An optional key that allows you specify the schema you want to verify against in compatible IDEs.\nIt is  advised that you leave this key out when submitting to the repo.",
-			"type": "string"
 		},
-
-		"monster": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"class": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"subclass": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"spell": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"action": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"item": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"itemGroup": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"baseitem": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"variant": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"background": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"charoption": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"condition": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"disease": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"status": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"cult": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"boon": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"psionic": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"psionicDisciplineFocus": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"race": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"subrace": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"vehicle": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-
-		"feat": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"optionalfeature": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"reward": {"$ref": "#/definitions/foundrySideDataGenericArray"},
-		"vehicleUpgrade": {"$ref": "#/definitions/foundrySideDataGenericArray"},
 
 		"raceFeature": {
 			"type": "array",
-				"items": {
-					"allOf": [
+			"items": {
+				"allOf": [
 					{"$ref": "#/definitions/foundrySideDataGeneric"},
 					{
 						"type": "object",
@@ -178,8 +147,8 @@
 
 		"classFeature": {
 			"type": "array",
-				"items": {
-					"allOf": [
+			"items": {
+				"allOf": [
 					{"$ref": "#/definitions/foundrySideDataGeneric"},
 					{
 						"type": "object",
@@ -203,8 +172,8 @@
 
 		"subclassFeature": {
 			"type": "array",
-				"items": {
-					"allOf": [
+			"items": {
+				"allOf": [
 					{"$ref": "#/definitions/foundrySideDataGeneric"},
 					{
 						"type": "object",
@@ -213,7 +182,7 @@
 							"classSource": {"type": "string"},
 							"level":  {"type": "integer"},
 							"subclassShortName": {"type": "string"},
-							"subclassSource":{"type": "string"}
+							"subclassSource": {"type": "string"}
 						},
 						"required": [
 							"name",
@@ -275,7 +244,5 @@
 			},
 			"uniqueItems": true
 		}
-	},
-
-	"additionalProperties": false
+	}
 }

--- a/test/test-json.js
+++ b/test/test-json.js
@@ -2,6 +2,8 @@ import Ajv from "ajv";
 import * as jsonSourceMap from "json-source-map";
 import * as kludge from "../script/kludge.js";
 
+console.log(`Testing JSON files against schema.`);
+
 const ajv = new Ajv({
 	allowUnionTypes: true,
 });
@@ -11,15 +13,22 @@ ajv.addKeyword({
 	validate: false,
 });
 
-const schema = kludge.readJsonSync("./test/schema/data.json");
+kludge.lsRecursiveSync("./test/schema")
+	.forEach(it => {
+		const schema = kludge.readJsonSync(it);
+		ajv.addSchema(schema, it.$id);
+	});
 
 let isFail = false;
 kludge.lsRecursiveSync("./module/data")
 	.filter(it => !it.includes("_generated") && it.endsWith(".json"))
 	.forEach(path => {
-		console.log(`Testing ${path}`);
+		const isCore = path.includes("__core.json");
+
+		console.log(`\tTesting (${isCore ? "core" : "brew"}) ${path}`);
+
 		const data = kludge.readJsonSync(path);
-		const valid = ajv.validate(schema, data);
+		const valid = ajv.validate(isCore ? "core.json" : "homebrew.json", data);
 		if (valid) return;
 
 		// Add line numbers
@@ -30,7 +39,9 @@ kludge.lsRecursiveSync("./module/data")
 			it.lineNumberEnd = errorPointer.valueEnd.line;
 		});
 
-		const out = ajv.errors.map(it => JSON.stringify(it, null, 2)).join("\n");
+		const out = ajv.errors.map(it => JSON.stringify(it, null, 2))
+			.map(str => str.split("\n").map(l => `\t${l}`).join("\n"))
+			.join("\n");
 		console.error(out);
 		isFail = true;
 	});


### PR DESCRIPTION
This demonstrates a simple `_meta` addon which has the "important bits"
of the standard homebrew `_meta`, in a slightly-flattened format (this
is due to each homebrew file in this repo matching exactly one homebrew
`"json"` source, whereas a file in the homebrew repo can contain
multiple `"json"` sources).

We choose to omit the `author`, `url`, etc. properties, as this
information is already stored in the homebrew repo, and duplicating it
has no benefit.