### PR TITLE
Revert on-rest AE expiry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@
 
 # Node
 node_modules
-package-lock.json
-package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 # Node
 node_modules
+package-lock.json
+package-lock.json

--- a/module/data/optionalfeature/__core.json
+++ b/module/data/optionalfeature/__core.json
@@ -28,14 +28,8 @@
 					"duration": {
 						"seconds": 60
 					},
-					"flags": {
-						"dnd5e-helpers": {
-							"rest-effect": "Short Rest"
-						}
-					},
 					"requires": {
-						"midi-qol": true,
-						"dnd5e-helpers": true
+						"midi-qol": true
 					}
 				}
 			],

--- a/module/data/spell/__core.json
+++ b/module/data/spell/__core.json
@@ -25,14 +25,10 @@
 							"specialDuration": [
 								"turnEndSource"
 							]
-						},
-						"dnd5e-helpers": {
-							"rest-effect": "Short Rest"
 						}
 					},
 					"requires": {
-						"dae": true,
-						"dnd5e-helpers": true
+						"dae": true
 					}
 				}
 			]
@@ -59,14 +55,8 @@
 					"duration": {
 						"seconds": 60
 					},
-					"flags": {
-						"dnd5e-helpers": {
-							"rest-effect": "Short Rest"
-						}
-					},
 					"requires": {
-						"midi-qol": true,
-						"dnd5e-helpers": true
+						"midi-qol": true
 					}
 				}
 			]
@@ -124,14 +114,10 @@
 								"isSave",
 								"turnEndSource"
 							]
-						},
-						"dnd5e-helpers": {
-							"rest-effect": "Short Rest"
 						}
 					},
 					"requires": {
-						"dae": true,
-						"dnd5e-helpers": true
+						"dae": true
 					}
 				}
 			],
@@ -165,15 +151,11 @@
 								"isSkill",
 								"1Attack"
 							]
-						},
-						"dnd5e-helpers": {
-							"rest-effect": "Short Rest"
 						}
 					},
 					"requires": {
 						"midi-qol": true,
-						"dae": true,
-						"dnd5e-helpers": true
+						"dae": true
 					}
 				}
 			]
@@ -193,14 +175,6 @@
 					],
 					"duration": {
 						"seconds": 3600
-					},
-					"flags": {
-						"dnd5e-helpers": {
-							"rest-effect": "Short Rest"
-						}
-					},
-					"requires": {
-						"dnd5e-helpers": true
 					}
 				}
 			]

--- a/module/data/subclassFeature/__core.json
+++ b/module/data/subclassFeature/__core.json
@@ -39,14 +39,8 @@
 					"duration": {
 						"seconds": 60
 					},
-					"flags": {
-						"dnd5e-helpers": {
-							"rest-effect": "Short Rest"
-						}
-					},
 					"requires": {
-						"midi-qol": true,
-						"dnd5e-helpers": true
+						"midi-qol": true
 					}
 				}
 			]


### PR DESCRIPTION
1) Can be handled by DAE for one less dependency
2) Can cause unexpected problems (e.g. _catnap_ spell); use `about-time` for out-of-combat AE expiry

Ran the `npm t` test and got no problems. Separately, since I'm by no means a node expert, but should I be pushing any changes to `package-lock.json` here? I noticed in the npm documentation it says that it's _intended_ to be committed, but I'm wary of overwriting whatever you have (since many lines were removed in the diff).