### PR TITLE
feat(module): add `midi-qol`, `dae`, and `times-up` as hard dependencies

### DIFF
--- a/MODULE_README.md
+++ b/MODULE_README.md
@@ -2,10 +2,5 @@
 
 ### Usage
 
-1) Install Plutonium, and any number of the following supported modules (for best results, install _all_ of the following supported modules)
-   1) [Dynamic Active Effects](https://foundryvtt.com/packages/dae)
-   2) [Midi Quality of Life Improvements](https://foundryvtt.com/packages/midi-qol/)
-   3) [About Time](https://foundryvtt.com/packages/about-time)
-   4) [Times Up](https://foundryvtt.com/packages/times-up)
-   5) [DFreds Convenient Effects](https://foundryvtt.com/packages/dfreds-convenient-effects)
+1) Install Plutonium, this module, and all its dependencies.
 2) Import content via Plutonium as normal!

--- a/module/data/classFeature/__core.json
+++ b/module/data/classFeature/__core.json
@@ -23,11 +23,6 @@
 								"turnEndSource"
 							]
 						}
-					},
-					"requires": {
-						"midi-qol": true,
-						"dae": true,
-						"times-up": true
 					}
 				}
 			]

--- a/module/data/feat/__core.json
+++ b/module/data/feat/__core.json
@@ -17,10 +17,6 @@
 						"dae": {
 							"transfer": true
 						}
-					},
-					"requires": {
-						"midi-qol": true,
-						"dae": true
 					}
 				}
 			]
@@ -42,10 +38,6 @@
 						"dae": {
 							"transfer": true
 						}
-					},
-					"requires": {
-						"midi-qol": true,
-						"dae": true
 					}
 				}
 			]

--- a/module/data/item/__core.json
+++ b/module/data/item/__core.json
@@ -17,10 +17,6 @@
 						"dae": {
 							"transfer": true
 						}
-					},
-					"requires": {
-						"midi-qol": true,
-						"dae": true
 					}
 				}
 			],

--- a/module/data/optionalfeature/__core.json
+++ b/module/data/optionalfeature/__core.json
@@ -27,11 +27,6 @@
 					],
 					"duration": {
 						"seconds": 60
-					},
-					"requires": {
-						"midi-qol": true,
-						"dae": true,
-						"times-up": true
 					}
 				}
 			],

--- a/module/data/spell/GiddySpell.json
+++ b/module/data/spell/GiddySpell.json
@@ -24,10 +24,6 @@
 			"effects": [
 				{
 					"name": "Crushed",
-					"requires": {
-						"dae": true,
-						"midi-qol": true
-					},
 					"changes": [
 						{
 							"key": "data.traits.size",

--- a/module/data/spell/WJMAiS.json
+++ b/module/data/spell/WJMAiS.json
@@ -26,13 +26,7 @@
 							"value": "Convenient Effect: Paralyzed",
 							"priority": "20"
 						}
-					],
-					"requires": {
-						"midi-qol": true,
-						"dae": true,
-						"times-up": true,
-						"dfreds-convenient-effects": true
-					}
+					]
 				}
 			]
 		}

--- a/module/data/spell/__core.json
+++ b/module/data/spell/__core.json
@@ -26,10 +26,6 @@
 								"turnEndSource"
 							]
 						}
-					},
-					"requires": {
-						"dae": true,
-						"times-up": true
 					}
 				}
 			]
@@ -55,11 +51,6 @@
 					],
 					"duration": {
 						"seconds": 60
-					},
-					"requires": {
-						"midi-qol": true,
-						"dae": true,
-						"times-up": true
 					}
 				}
 			]
@@ -82,13 +73,7 @@
 							"value": "Convenient Effect: Paralyzed",
 							"priority": "20"
 						}
-					],
-					"requires": {
-						"midi-qol": true,
-						"dae": true,
-						"times-up": true,
-						"dfreds-convenient-effects": true
-					}
+					]
 				}
 			]
 		},
@@ -146,10 +131,6 @@
 								"turnEndSource"
 							]
 						}
-					},
-					"requires": {
-						"dae": true,
-						"times-up": true
 					}
 				}
 			],
@@ -184,11 +165,6 @@
 								"1Attack"
 							]
 						}
-					},
-					"requires": {
-						"midi-qol": true,
-						"dae": true,
-						"times-up": true
 					}
 				}
 			]
@@ -232,11 +208,6 @@
 								"shortRest"
 							]
 						}
-					},
-					"requires": {
-						"midi-qol": true,
-						"dae": true,
-						"times-up": true
 					}
 				}
 			]

--- a/module/data/subclassFeature/__core.json
+++ b/module/data/subclassFeature/__core.json
@@ -38,10 +38,6 @@
 					],
 					"duration": {
 						"seconds": 60
-					},
-					"requires": {
-						"midi-qol": true,
-						"dae": true
 					}
 				}
 			]

--- a/script/build-task.js
+++ b/script/build-task.js
@@ -33,6 +33,26 @@ const MODULE_JSON =
 				"type": "module",
 				"manifest": "https://raw.githubusercontent.com/TheGiddyLimit/plutonium-next/master/module.json",
 			},
+			{
+				"name": "midi-qol",
+				"type": "module",
+				"manifest": "https://gitlab.com/tposney/midi-qol/raw/master/package/module.json",
+			},
+			{
+				"name": "dae",
+				"type": "module",
+				"manifest": "https://gitlab.com/tposney/dae/raw/master/package/module.json",
+			},
+			{
+				"name": "times-up",
+				"type": "module",
+				"manifest": "https://gitlab.com/tposney/times-up/raw/master/package/module.json",
+			},
+			{
+				"name": "dfreds-convenient-effects",
+				"type": "module",
+				"manifest": "https://github.com/DFreds/dfreds-convenient-effects/releases/latest/download/module.json",
+			},
 		],
 		"esmodules": [
 			"./js/Main.js",

--- a/test/schema/shared.json
+++ b/test/schema/shared.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "shared.json",
-	"version": "0.2.0",
+	"version": "0.2.1",
 
 	"definitions": {
 		"schema": {
@@ -16,9 +16,23 @@
 
 				"requires": {
 					"type": "object",
-					"description": "Each key should correspond to a Foundry module's \"name\" field, which can be found in that module's \"module.json\" (or at the end of the Foundry module page URL, e.g. \"https://foundryvtt.com/packages/dae\")",
+					"description": "Each key should correspond to a Foundry module's \"name\" field, which can be found in that module's \"module.json\" (or at the end of the Foundry module page URL, e.g. the \"JB2A_DnD5e\" in \"https://foundryvtt.com/packages/JB2A_DnD5e\")",
+
 					"patternProperties": {
 						"^.*$": {"const": true}
+					},
+
+					"propertyNames": {
+						"not": {
+							"$comment": "The modules listed here are module dependencies, so are implicitly required.",
+							"enum": [
+								"plutonium",
+								"midi-qol",
+								"dae",
+								"times-up",
+								"dfreds-convenient-effects"
+							]
+						}
 					}
 				},
 


### PR DESCRIPTION
This set of modules is to be considered the (current) core we build
everything out from. To avoid adding the same requirement to hundreds of
effects/etc., we depend on these three modules at the module level.