### PR TITLE
feat(core): use "_merge" in Sentinel Shield effects

### DIFF
--- a/module/data/item/__core.json
+++ b/module/data/item/__core.json
@@ -7,12 +7,6 @@
 				{
 					"changes": [
 						{
-							"key": "flags.dnd5e.initiativeAdv",
-							"mode": 0,
-							"value": "1",
-							"priority": "20"
-						},
-						{
 							"key": "flags.midi-qol.advantage.skill.prc",
 							"mode": 0,
 							"value": "1",
@@ -29,7 +23,10 @@
 						"dae": true
 					}
 				}
-			]
+			],
+			"_merge": {
+				"effects": true
+			}
 		}
 	]
 }

--- a/test/schema/shared.json
+++ b/test/schema/shared.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "shared.json",
-	"version": "0.1.0",
+	"version": "0.2.0",
 
 	"definitions": {
 		"schema": {
@@ -77,7 +77,7 @@
 					]
 				},
 
-				"merge": {
+				"_merge": {
 					"type": "object",
 					"description": "If our \"X\" (e.g. \"data\") should be merged with any base \"X\", rather than overwriting.",
 					"properties": {


### PR DESCRIPTION
This provides a helpful example of how/why to use this, as the
"flags.dnd5e.initiativeAdv" effect is built in to Plutonium already.