### PR TITLE
test(json): harder enforcement of empty arrays and effect modes, require _meta

### DIFF
--- a/module/data/spell/__core.json
+++ b/module/data/spell/__core.json
@@ -34,7 +34,7 @@
 					"changes": [
 						{
 							"key": "data.traits.ci.value",
-							"mode": "SELECTED",
+							"mode": "ADD",
 							"value": "frightened",
 							"priority": "20"
 						},
@@ -81,37 +81,37 @@
 					"changes": [
 						{
 							"key": "data.abilities.str.bonuses.save",
-							"mode": "SELECTED",
+							"mode": "ADD",
 							"value": "-1d4",
 							"priority": "20"
 						},
 						{
 							"key": "data.abilities.dex.bonuses.save",
-							"mode": "SELECTED",
+							"mode": "ADD",
 							"value": "-1d4",
 							"priority": "20"
 						},
 						{
 							"key": "data.abilities.con.bonuses.save",
-							"mode": "SELECTED",
+							"mode": "ADD",
 							"value": "-1d4",
 							"priority": "20"
 						},
 						{
 							"key": "data.abilities.int.bonuses.save",
-							"mode": "SELECTED",
+							"mode": "ADD",
 							"value": "-1d4",
 							"priority": "20"
 						},
 						{
 							"key": "data.abilities.wis.bonuses.save",
-							"mode": "SELECTED",
+							"mode": "ADD",
 							"value": "-1d4",
 							"priority": "20"
 						},
 						{
 							"key": "data.abilities.cha.bonuses.save",
-							"mode": "SELECTED",
+							"mode": "ADD",
 							"value": "-1d4",
 							"priority": "20"
 						}

--- a/module/data/subclassFeature/__core.json
+++ b/module/data/subclassFeature/__core.json
@@ -13,13 +13,13 @@
 					"changes": [
 						{
 							"key": "data.attributes.ac.bonus",
-							"mode": "SELECTED",
+							"mode": "ADD",
 							"value": "max(1,@abilities.int.mod)",
 							"priority": "20"
 						},
 						{
 							"key": "data.attributes.movement.walk",
-							"mode": "SELECTED",
+							"mode": "ADD",
 							"value": "10",
 							"priority": "20"
 						},
@@ -31,7 +31,7 @@
 						},
 						{
 							"key": "flags.midi-qol.concentrationSaveBonus",
-							"mode": "SELECTED",
+							"mode": "ADD",
 							"value": "max(1,@abilities.int.mod)",
 							"priority": "20"
 						}

--- a/test/schema/core.json
+++ b/test/schema/core.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "core.json",
-	"version": "0.1.0",
+	"version": "0.1.1",
 
 	"type": "object",
 
@@ -43,5 +43,6 @@
 		"vehicleWeapon": {"$ref": "shared.json#/definitions/vehicleWeapon"}
 	},
 
-	"additionalProperties": false
+	"additionalProperties": false,
+	"minProperties": 1
 }

--- a/test/schema/homebrew.json
+++ b/test/schema/homebrew.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "homebrew.json",
-	"version": "0.1.0",
+	"version": "0.1.1",
 
 	"$comment": "Note: for homebrew files (i.e., those *not* names \"__core.json\"), the file should be named `<brewSourceJson>.json`, where <brewSourceJson> matches the `\"json\": \"MySourceName\"` value for the corresponding source in the homebrew repository.",
 
@@ -78,5 +78,9 @@
 		"vehicleWeapon": {"$ref": "shared.json#/definitions/vehicleWeapon"}
 	},
 
-	"additionalProperties": false
+	"additionalProperties": false,
+	"minProperties": 2,
+	"required": [
+		"_meta"
+	]
 }

--- a/test/schema/shared.json
+++ b/test/schema/shared.json
@@ -1,12 +1,18 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "shared.json",
-	"version": "0.2.2",
+	"version": "0.2.3",
 
 	"definitions": {
 		"schema": {
 			"description": "An optional key that allows you specify the schema you want to verify against in compatible IDEs.\nIt is  advised that you leave this key out when submitting to the repo.",
-			"type": "string"
+			"type": "string",
+			"examples": [
+				"../../../test/schema/homebrew.json",
+				"../../../test/schema/core.json",
+				"https://raw.githubusercontent.com/TheGiddyLimit/plutonium-addon-data/master/test/schema/homebrew.json",
+				"https://raw.githubusercontent.com/TheGiddyLimit/plutonium-addon-data/master/test/schema/core.json"
+			]
 		},
 
 		"foundryEffectObject": {
@@ -42,14 +48,15 @@
 						"type": "object",
 						"properties": {
 							"key": {"type": "string"},
-							"mode": {"type": ["string", "integer"]},
+							"mode": {"type": ["string", "integer"], "enum": ["CUSTOM", 0, "MULTIPLY", 1, "ADD", 2, "DOWNGRADE", 3, "UPGRADE", 4, "OVERRIDE", 5]},
 							"priority": {"type": ["string", "integer"]},
-							"value": true
+							"value": {"type": "string"}
 						},
 						"required": ["key", "mode", "value"],
 						"additionalProperties": false
 					},
-					"uniqueItems": true
+					"uniqueItems": true,
+					"minItems": 1
 				},
 
 				"flags": {"type": "object"},
@@ -70,7 +77,12 @@
 
 				"data": {"type": "object"},
 
-				"effects": {"type": "array", "items": {"$ref": "#/definitions/foundryEffectObject"}, "uniqueItems": true},
+				"effects": {
+					"type": "array",
+					"items": {"$ref": "#/definitions/foundryEffectObject"},
+					"uniqueItems": true,
+					"minItems": 1
+				},
 
 				"flags": {"type": "object"},
 
@@ -111,7 +123,8 @@
 		"foundrySideDataGenericArray": {
 			"type": "array",
 			"uniqueItems": true,
-			"items": {"$ref": "#/definitions/foundrySideDataGeneric"}
+			"items": {"$ref": "#/definitions/foundrySideDataGeneric"},
+			"minItems": 1
 		},
 
 		"raceFeature": {
@@ -135,7 +148,8 @@
 					}
 				]
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"backgroundFeature": {
@@ -159,7 +173,8 @@
 					}
 				]
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"classFeature": {
@@ -185,7 +200,8 @@
 					}
 				]
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"subclassFeature": {
@@ -215,7 +231,8 @@
 					}
 				]
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"psionicDisciplineActive": {
@@ -239,7 +256,8 @@
 					}
 				]
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		},
 
 		"vehicleWeapon": {
@@ -263,7 +281,8 @@
 					}
 				]
 			},
-			"uniqueItems": true
+			"uniqueItems": true,
+			"minItems": 1
 		}
 	}
 }

--- a/tool/public/client.js
+++ b/tool/public/client.js
@@ -151,7 +151,7 @@ class Converter {
 		switch (modeRaw) {
 			case 0: return "CUSTOM";
 			case 1: return "MULTIPLY";
-			case 2: return "SELECTED";
+			case 2: return "ADD";
 			case 3: return "DOWNGRADE";
 			case 4: return "UPGRADE";
 			case 5: return "OVERRIDE";


### PR DESCRIPTION
Also `$schema` `examples` for ease of use